### PR TITLE
Remove BuildRoot tag

### DIFF
--- a/rpmkit.spec.in
+++ b/rpmkit.spec.in
@@ -10,7 +10,6 @@ Group:          Development/Tools
 License:        GPLv3+
 URL:            https://github.com/ssato/rpmkit
 Source0:        https://github.com/ssato/rpmkit/tarball/master/%{name}-%{version}.tar.gz
-BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 BuildRequires:  python
 BuildRequires:  /usr/bin/pygettext.py

--- a/rpmkit.spec.in
+++ b/rpmkit.spec.in
@@ -10,6 +10,9 @@ Group:          Development/Tools
 License:        GPLv3+
 URL:            https://github.com/ssato/rpmkit
 Source0:        https://github.com/ssato/rpmkit/tarball/master/%{name}-%{version}.tar.gz
+%if 0%{?rhel} && 0%{?rhel} <= 5
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+%endif
 BuildArch:      noarch
 BuildRequires:  python
 BuildRequires:  /usr/bin/pygettext.py


### PR DESCRIPTION
BuildRoot tag is obsolete[1].

[1] https://fedoraproject.org/wiki/Packaging:Guidelines#BuildRoot_tag
